### PR TITLE
Fix looping on Galaxy S5 running 4.4.4

### DIFF
--- a/Gfycat/src/main/java/net/danlew/gfycat/ui/MainActivity.java
+++ b/Gfycat/src/main/java/net/danlew/gfycat/ui/MainActivity.java
@@ -348,6 +348,16 @@ public class MainActivity extends Activity implements ErrorDialog.IListener {
                         }
                     });
 
+                    // Enable looping for Samsung devices, tested on Galaxy S5 (4.4.4)
+                    mediaPlayer.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
+                            @Override
+                            public void onCompletion(MediaPlayer mediaPlayer) {
+                                mediaPlayer.pause();
+                                mediaPlayer.seekTo(0);
+                                mediaPlayer.start();
+                            }
+                    });
+
                     try {
                         mediaPlayer.setDataSource(gfyMetadata.getGfyItem().getWebmUrl());
                         mediaPlayer.setSurface(new Surface(mVideoView.getSurfaceTexture()));


### PR DESCRIPTION
What I've observed is that when the video stops and the onCompletion() method is called, the position of the video is not the same as the duration of the video.  For example, a gfy with a duration of 6800 will end at 6600, or another one with a duration of 7400 ends at 7340.  I don't know why this happens.  Waiting in the onCompletion() method for the duration to finish does not work.  Attempting to call seekTo() and start() also does not seem to work.

I did however notice this message:
2263-2263/net.danlew.gfycat E/MediaPlayer﹕ internal/external state mismatch corrected

Calling mediaPlayer.isPlaying() before seekTo() and start() does not prevent the error message, but does appear to enable looping.

Interestingly a call to pause() before seekTo() and start() seems to prevent the state mismatch error and also enable looping.  For some reason the internal state of the MediaPlayer object is not right and is preventing looping from working on my particular device.
