### PR TITLE
Null MediaPlayer check onPause and onResume

### DIFF
--- a/Gfycat/src/main/java/net/danlew/gfycat/ui/MainActivity.java
+++ b/Gfycat/src/main/java/net/danlew/gfycat/ui/MainActivity.java
@@ -211,16 +211,18 @@ public class MainActivity extends Activity implements ErrorDialog.IListener {
 
     @Override
     public void onPause() {
-	super.onPause();
-        if (mMediaPlayer != null && mMediaPlayerPrepared)
-        	mMediaPlayer.pause();
+        super.onPause();
+        if (mMediaPlayer != null && mMediaPlayerPrepared) {
+            mMediaPlayer.pause();            
+        }
     }
 
     @Override
     public void onResume() {
-    	super.onResume();
-        if (mMediaPlayer != null && mMediaPlayerPrepared)
-        	mMediaPlayer.start();
+        super.onResume();
+        if (mMediaPlayer != null && mMediaPlayerPrepared) {
+            mMediaPlayer.start();            
+        }
     }
 
     @Override

--- a/Gfycat/src/main/java/net/danlew/gfycat/ui/MainActivity.java
+++ b/Gfycat/src/main/java/net/danlew/gfycat/ui/MainActivity.java
@@ -210,15 +210,17 @@ public class MainActivity extends Activity implements ErrorDialog.IListener {
     }
 
     @Override
-    public void onPause(){
+    public void onPause() {
 	super.onPause();
-	mMediaPlayer.pause();
+        if (mMediaPlayer != null && mMediaPlayerPrepared)
+        	mMediaPlayer.pause();
     }
 
     @Override
-    public void onResume(){
-	super.onResume();
-	mMediaPlayer.start();
+    public void onResume() {
+    	super.onResume();
+        if (mMediaPlayer != null && mMediaPlayerPrepared)
+        	mMediaPlayer.start();
     }
 
     @Override


### PR DESCRIPTION
Null check on MediaPlayer and confirmation that MediaPlayer is prepared onPause and onResume. For example, the application as is crashes on startup since the MediaPlayer is prepared asynchronously, and the call to `start()` in onResume is made prior to that preparation being complete.