### PR TITLE
Use HTTPS for service URLs

### DIFF
--- a/Gfycat/src/main/java/net/danlew/gfycat/service/GfycatService.java
+++ b/Gfycat/src/main/java/net/danlew/gfycat/service/GfycatService.java
@@ -50,7 +50,7 @@ public class GfycatService {
 
         mConvertService = new Retrofit.Builder()
             .client(okHttpClient)
-            .baseUrl("http://upload.gfycat.com/")
+            .baseUrl("https://upload.gfycat.com/")
             .addCallAdapterFactory(rxJavaCallAdapterFactory)
             .addConverterFactory(gsonConverterFactory)
             .build()
@@ -58,7 +58,7 @@ public class GfycatService {
 
         mService = new Retrofit.Builder()
             .client(okHttpClient)
-            .baseUrl("http://gfycat.com/")
+            .baseUrl("https://gfycat.com/")
             .addCallAdapterFactory(rxJavaCallAdapterFactory)
             .addConverterFactory(gsonConverterFactory)
             .build()


### PR DESCRIPTION
The gfycat servers return a `HTTP/1.1 301 Moved Permanently` header when accessing them via HTTP, this will save a redirect every time the service URLs are called